### PR TITLE
respect XDG Base Directory Specification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 #########
 
+* Respect the XDG Base Directory specification (http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+
 4.0.1 (2015-04-03)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ tests_require = [
 install_requires = [
     'click>=3.3',
     'six>=1.9.0',
+    'appdirs>=1.4.0',
 ]
 
 

--- a/taxi/commands/add.py
+++ b/taxi/commands/add.py
@@ -15,7 +15,7 @@ def add(ctx, search):
     Usage: add search_string
 
     Searches and prompts for project, activity and alias and adds that as a new
-    entry to .taxirc.
+    entry to the config file.
 
     """
     projects = ctx.obj['projects_db'].search(search, active_only=True)

--- a/taxi/commands/base.py
+++ b/taxi/commands/base.py
@@ -6,6 +6,7 @@ import sys
 
 import click
 import six
+from appdirs import AppDirs
 
 from .types import ExpandedPath, Hostname
 from ..aliases import aliases_database
@@ -15,6 +16,9 @@ from ..settings import Settings
 from ..timesheet.utils import get_timesheet_collection
 from ..ui.tty import TtyUi
 from .. import __version__
+
+
+xdg_dirs = AppDirs("taxi", "sephii")
 
 
 # Disable click 5.0 unicode_literals warnings. See
@@ -101,6 +105,10 @@ def create_config_file(filename):
                 "timesheets.example.com)", type=Hostname()
             )
             templated_config = config.format(**context)
+
+            directory = os.path.dirname(filename)
+            if not os.path.exists(directory):
+                os.makedirs(directory)
             with open(filename, 'w') as f:
                 f.write(templated_config)
         else:
@@ -158,11 +166,29 @@ def print_version(ctx, param, value):
     ctx.exit()
 
 
+def get_config_file():
+    name='taxirc'
+
+    home = os.path.join(os.path.expanduser('~'), '.' + name)
+    if os.path.isfile(home):
+        return home
+
+    return os.path.join(xdg_dirs.user_config_dir, name)
+
+
+def get_data_dir():
+    home = os.path.join(os.path.expanduser('~'), '.taxi')
+    if os.path.isdir(home):
+        return home
+
+    return xdg_dirs.user_data_dir
+
+
 @click.group(cls=AliasedGroup)
-@click.option('--config', '-c', default='~/.taxirc',
+@click.option('--config', '-c', default=get_config_file(),
               type=ExpandedPath(dir_okay=False),
               help="Path to the configuration file to use.")
-@click.option('--taxi-dir', default='~/.taxi',
+@click.option('--taxi-dir', default=get_data_dir(),
               type=ExpandedPath(file_okay=False), help="Path to the directory "
               "that will be used for internal files.")
 @click.option('--version', is_flag=True, callback=print_version,
@@ -173,8 +199,8 @@ def cli(ctx, config, taxi_dir):
     create_config_file(config)
     settings = Settings(config)
 
-    if not os.path.exists(settings.TAXI_PATH):
-        os.mkdir(settings.TAXI_PATH)
+    if not os.path.exists(taxi_dir):
+        os.makedirs(taxi_dir)
 
     populate_aliases(settings.get_aliases(), settings.get_local_aliases())
     populate_backends(settings.get_backends())

--- a/taxi/settings.py
+++ b/taxi/settings.py
@@ -12,7 +12,6 @@ from .utils.file import expand_date as file_expand_date
 
 
 class Settings(dict):
-    TAXI_PATH = os.path.expanduser('~/.taxi')
     AUTO_ADD_OPTIONS = {
         'NO': 'no',
         'TOP': 'top',


### PR DESCRIPTION
Respect the specification here : http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html

One difference though, we only use this when the environment variable is set instead of defaulting to ~/.config and ~/.local/share so that people currently having their configuration in their ~ have no issue.

We could eventually imagine a migration process and respect the spec fully.

If we go this way, we need to take care of Mac OS X (http://stackoverflow.com/questions/3373948/equivalents-of-xdg-config-home-and-xdg-data-home-on-mac-os-x#answer-5084892) and Windows.