### PR TITLE
Fix the call to round_to_quarter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
 python:
+ - 2.7
+ - 3.3
+ - 3.4
  - 3.5
-env:
-  - TOXENV=py27
-  - TOXENV=py34
-  - TOXENV=py35
+ - 3.6
 install:
   - pip install tox
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export TOXENV=py27; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then export TOXENV=py33; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export TOXENV=py34; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export TOXENV=py35; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export TOXENV=py36; fi"
 script:
   - tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 #########
 
+4.4.1 (unreleased)
+==================
+
+Added
+-----
+
+* Add tests for the stop command
+
+Changed
+-------
+
+* Fix the broken stop command (#111)
+
 4.4.0 (2017-11-27)
 ==================
 

--- a/taxi/commands/stop.py
+++ b/taxi/commands/stop.py
@@ -4,7 +4,7 @@ import datetime
 
 import click
 
-from ..exceptions import NoActivityInProgressError, ParseError
+from ..exceptions import NoActivityInProgressError, ParseError, StopInThePastError
 from .base import cli, get_timesheet_collection_for_context
 
 
@@ -29,8 +29,9 @@ def stop(ctx, description, f):
         )
     except ParseError as e:
         ctx.obj['view'].err(e)
-    except NoActivityInProgressError:
-        ctx.obj['view'].err("You don't have any activity in progress for "
-                            "today")
+    except NoActivityInProgressError as e:
+        ctx.obj['view'].err(e)
+    except StopInThePastError as e:
+        ctx.obj['view'].err(e)
     else:
         current_timesheet.save()

--- a/taxi/exceptions.py
+++ b/taxi/exceptions.py
@@ -43,3 +43,7 @@ class ParseError(TaxiException):
 
 class NoActivityInProgressError(TaxiException):
     pass
+
+
+class StopInThePastError(TaxiException):
+    pass

--- a/taxi/timesheet/timesheet.py
+++ b/taxi/timesheet/timesheet.py
@@ -119,7 +119,7 @@ class Timesheet(object):
         if not entry.in_progress:
             raise NoActivityInProgressError()
 
-        entry.duration = (entry.duration[0], self.round_to_quarter(
+        entry.duration = (entry.duration[0], round_to_quarter(
             entry.duration[0],
             end_time
         ))

--- a/taxi/timesheet/timesheet.py
+++ b/taxi/timesheet/timesheet.py
@@ -8,7 +8,7 @@ from functools import reduce
 
 import six
 
-from ..exceptions import NoActivityInProgressError, ParseError
+from ..exceptions import NoActivityInProgressError, ParseError, StopInThePastError
 from ..utils import file as file_utils
 from ..utils.date import months_ago
 from ..utils.structures import OrderedSet
@@ -114,10 +114,13 @@ class Timesheet(object):
         try:
             entry = self.entries[date][-1]
         except IndexError:
-            raise NoActivityInProgressError()
+            raise NoActivityInProgressError("You don't have any activity in progress for today")
 
         if not entry.in_progress:
-            raise NoActivityInProgressError()
+            raise NoActivityInProgressError("You don't have any activity in progress for today")
+
+        if entry.get_start_time() > end_time:
+            raise StopInThePastError("You are trying to stop an activity in the future")
 
         entry.duration = (entry.duration[0], round_to_quarter(
             entry.duration[0],

--- a/tests/commands/test_stop.py
+++ b/tests/commands/test_stop.py
@@ -1,0 +1,69 @@
+from __future__ import unicode_literals
+
+from freezegun import freeze_time
+
+
+def test_description_entry_present(cli, entries_file):
+    entries = """20/01/2014
+alias_1 10:00-? Play tennis
+"""
+    expected = """20/01/2014
+alias_1 10:00-10:15 Play ping-pong
+"""
+
+    entries_file.write(entries)
+    with freeze_time('2014-01-20 10:10:00'):
+        cli('stop', ['Play ping-pong'])
+
+    assert entries_file.read() == expected
+
+
+def test_round_next_quarter(cli, entries_file):
+    entries = """20/01/2014
+alias_1 10:00-? ?
+"""
+    expected = """20/01/2014
+alias_1 10:00-10:15 Play ping-pong
+"""
+
+    entries_file.write(entries)
+    with freeze_time('2014-01-20 10:01:00'):
+        cli('stop', ['Play ping-pong'])
+
+    assert entries_file.read() == expected
+
+
+def test_stop_in_the_past(cli, entries_file):
+    entries = """20/01/2014
+alias_1 10:00-? ?
+"""
+
+    entries_file.write(entries)
+    with freeze_time('2014-01-20 09:30:00'):
+        output = cli('stop', ['Play ping-pong'])
+
+    assert output == 'Error: You are trying to stop an activity in the future\n'
+
+
+def test_stop_without_activity_started(cli, entries_file):
+    entries = """20/01/2014
+alias_1 10:00-10:30 Play ping-pong
+"""
+
+    entries_file.write(entries)
+    with freeze_time('2014-01-20 10:15:00'):
+        output = cli('stop', ['Play ping-pong'])
+
+    assert output == "Error: You don't have any activity in progress for today\n"
+
+
+def test_stop_with_non_parsable_entry(cli, entries_file):
+    entries = """20/01/2014
+alias 10:00-ff:ff Play ping-pong
+"""
+
+    entries_file.write(entries)
+    with freeze_time('2014-01-20'):
+        output = cli('stop', ['Play ping-pong'])
+
+    assert output.startswith('Error: Parse error')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35
+envlist = py27, py33, py34, py35, py36
 
 [testenv]
 commands = python setup.py test []


### PR DESCRIPTION
Stop command is failing as the round_to_quarter method is not in Timesheet class
`
Traceback (most recent call last):
  File "/home/r0x73/.local/bin/taxi", line 11, in <module>
    sys.exit(cli())
  File "/home/r0x73/.local/lib/taxi/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/r0x73/.local/lib/taxi/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/r0x73/.local/lib/taxi/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/r0x73/.local/lib/taxi/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/r0x73/.local/lib/taxi/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/r0x73/.local/lib/taxi/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/r0x73/.local/lib/taxi/lib/python3.6/site-packages/taxi/commands/stop.py", line 28, in stop
    description
  File "/home/r0x73/.local/lib/taxi/lib/python3.6/site-packages/taxi/timesheet/timesheet.py", line 122, in continue_entry
    entry.duration = (entry.duration[0], self.round_to_quarter(
AttributeError: 'Timesheet' object has no attribute 'round_to_quarter'
`