### PR TITLE
Update nix install

### DIFF
--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -9,7 +9,7 @@ To install Taxi, follow the steps below specific to your system.
 OS X, Windows, generic Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Make sure you have Python at least 3.5 installed (by running ``python3
+Make sure you have Python at least 3.7 installed (by running ``python3
 --version``), then use ``python3 -m pip`` to install taxi in your user directory
 (you should **not** use sudo or run this command as root)::
 
@@ -86,7 +86,7 @@ Run the following command::
     $ python --version
     Python 3.8.5
 
-Check that the version is at least 3.5. If that’s the case, replace ``python3``
+Check that the version is at least 3.7. If that’s the case, replace ``python3``
 by ``python`` when running commands. If that’s not the case, install Python 3.
 
 First steps with Taxi

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1630909447,
-        "narHash": "sha256-5sv1IZvIpRRrDTQPZHRE624A9CpjJtwpeA2TvVPV3vY=",
+        "lastModified": 1658056616,
+        "narHash": "sha256-ks9oZFDd880EKZBZ5uZY0guh+tfqMPt71t1YtsQoPa8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cdbc8c9fb1aeb198e20a63782c0e8b40155afce8",
+        "rev": "b3f5f7edd8e6179ea42ea724ee6b3bbf690b51f8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,13 +9,29 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        taxi = (import ./pkgs.nix { inherit pkgs; });
-      in {
-        packages = { inherit taxi; };
-        defaultPackage = taxi;
-        devShell = import ./shell.nix { inherit pkgs; };
-      });
+    let
+      # Recursively merge a list of attribute sets. Following elements take
+      # precedence over previous elements if they have conflicting keys.
+      recursiveMerge = with nixpkgs.lib; foldl recursiveUpdate { };
+    in
+    recursiveMerge [
+      (flake-utils.lib.eachDefaultSystem
+        (system:
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+            taxi = (import ./pkgs.nix { inherit pkgs; });
+          in
+          {
+            packages = { inherit taxi; };
+            defaultPackage = taxi;
+            devShell = import ./shell.nix { inherit pkgs; };
+          })
+      )
+      {
+        overlay = final: prev: rec {
+          # Prevents collision with taxi from nixpkgs (sftp app)
+          taxi-cli = self.packages.${prev.stdenv.hostPlatform.system}.taxi;
+        };
+      }
+    ];
 }

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -55,17 +55,18 @@ let
 
   taxiZebra = pkgs.python3Packages.buildPythonPackage rec {
     pname = "taxi_zebra";
-    version = "2.3.1";
+    version = "3.0.1";
 
-    src = pkgs.python3.pkgs.fetchPypi {
-      inherit pname version;
-      sha256 = "177fzasgchgbixrr4xikfbis8i427qlyb8c93d404rjjny9g7nny";
+    src = pkgs.fetchFromGitHub {
+      owner = "liip";
+      repo = "taxi-zebra";
+      rev = version;
+      sha256 = "sha256-5Sy/goElwLGt2Sg05Z8G04vsEZsTKCZKsI1/wQNifTI=";
     };
 
     buildInputs = [ taxi ];
     propagatedBuildInputs =
       [ pkgs.python3Packages.requests pkgs.python3Packages.click ];
-    doCheck = false;
 
     meta = {
       homepage = "https://github.com/liip/taxi-zebra";
@@ -119,7 +120,7 @@ let
   };
 
   availablePlugins = {
-    taxi = taxiZebra;
+    zebra = taxiZebra;
     petzi = taxiPetzi;
     clockify = taxiClockify;
   };

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     package_data={
         'taxi': ['etc/*']
     },
-    python_requires=">=3.5",
+    python_requires='>=3.7',
     entry_points={
         'taxi.backends': 'dummy = taxi.backends.dummy:DummyBackend',
         'console_scripts': 'taxi = taxi.commands.base:cli'
@@ -33,10 +33,9 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-    ]
+        'Programming Language :: Python :: 3.10',
+    ],
 )

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> { } }:
 
-with pkgs.python37Packages;
+with pkgs.python310Packages;
 
 buildPythonPackage rec {
   name = "taxi";


### PR DESCRIPTION
- Update flake.lock
- Update develop environment to latest python to benefit from the cache
- Remove EOL python versions
- Add an overlay output to more easily include the package into top-level pkgs
- rename taxi-zebra plugin from taxi to zebra
- Update taxi-zebra to latest version