### PR TITLE
Refactor nix tests

### DIFF
--- a/pkgs.nix
+++ b/pkgs.nix
@@ -39,8 +39,8 @@ let
 
     propagatedBuildInputs =
       [ python3.pkgs.click python3.pkgs.appdirs python3.pkgs.setuptools ];
-    checkInputs = [ python3.pkgs.freezegun ];
-    checkPhase = "${python3.pkgs.pytest}/bin/pytest";
+    nativeCheckInputs = [ python3.pkgs.pytest python3.pkgs.freezegun ];
+    checkPhase = "pytest";
 
     passthru = { inherit withPlugins; };
 

--- a/tests.nix
+++ b/tests.nix
@@ -1,3 +1,7 @@
 { python3, taxi, pkgs, ... }: taxi.overrideAttrs (old: {
+  dontBuild = true;
   dontInstall = true;
+  preConfigure = ''
+    pythonOutputDistPhase() { touch $dist; }
+  '';
 })


### PR DESCRIPTION
This follows a bit more closely what is seen in nixpkgs. E.g. checkInputs being replaced by nativeCheckInputs

The `preConfigure` is also needed due to changes in `buildPythonPackage` if we want to continue using `dontBuild` for tests :)