### PR TITLE
Handle potentially inactive activities

### DIFF
--- a/taxi/commands/alias.py
+++ b/taxi/commands/alias.py
@@ -120,7 +120,7 @@ def list_aliases(ctx, search, backend, used, inactive):
         else:
             project = None
 
-        if not inactive and (not project or not project.is_active()):
+        if not inactive and ((not project or not project.is_active()) or (activity and not activity.is_active())):
             continue
 
         ctx.obj['view'].alias_detail((alias, m), project)

--- a/taxi/commands/alias.py
+++ b/taxi/commands/alias.py
@@ -35,7 +35,7 @@ def list_(ctx, search_string, reverse, backend, used, inactive):
     will probably result in an error.
     """
     if not reverse:
-        list_aliases(ctx, search_string, backend, used, inactive=inactive)
+        list_aliases(ctx, search_string, backend, used, include_inactive=inactive)
     else:
         show_mapping(ctx, search_string, backend)
 
@@ -102,7 +102,7 @@ def show_mapping(ctx, mapping_str, backend):
         )
 
 
-def list_aliases(ctx, search, backend, used, inactive):
+def list_aliases(ctx, search, backend, used, include_inactive: bool):
     aliases_mappings = aliases_database.filter_from_alias(search, backend)
 
     if used:
@@ -119,8 +119,10 @@ def list_aliases(ctx, search, backend, used, inactive):
             project, activity = ctx.obj['projects_db'].mapping_to_project(m)
         else:
             project = None
+            activity = None
 
-        if not inactive and ((not project or not project.is_active()) or (activity and not activity.is_active())):
-            continue
+        project_is_active = project and project.is_active()
+        activity_is_active = activity and activity.is_active()
 
-        ctx.obj['view'].alias_detail((alias, m), project)
+        if include_inactive or (project_is_active and activity_is_active):
+            ctx.obj['view'].alias_detail((alias, m), project)

--- a/taxi/projects.py
+++ b/taxi/projects.py
@@ -118,9 +118,13 @@ Description: %s""" % (self.id, self.name, status, start_date, end_date,
 
 
 class Activity:
-    def __init__(self, id, name):
+    def __init__(self, id: str, name: str, active: bool = True):
         self.id = id
         self.name = name
+        self._active = active
+
+    def is_active(self) -> bool:
+        return self._active
 
 
 class ProjectsDb:
@@ -268,7 +272,7 @@ class LocalProjectsDbDecoder(json.JSONDecoder):
         projects_copy = []
         for project in projects:
             project['activities'] = [
-                Activity(str(activity['id']), activity['name'])
+                Activity(str(activity['id']), activity['name'], activity.get('_active', True))
                 for activity in project['activities']
             ]
             project['id'] = str(project['id'])

--- a/taxi/ui/__init__.py
+++ b/taxi/ui/__init__.py
@@ -159,10 +159,12 @@ class BaseUi(object):
             return
 
         mapping_name = Project.tuple_to_str(mapping.mapping)
+        mapping_is_active = True
 
         if not project:
             project_name = ''
         else:
+            mapping_is_active = project.is_active()
             if mapping.mapping[1] is None:
                 project_name = project.name
                 mapping_name = mapping.mapping[0]
@@ -172,6 +174,8 @@ class BaseUi(object):
                 if activity is None:
                     project_name = '%s, ?' % (project.name)
                 else:
+                    if mapping_is_active:
+                        mapping_is_active = activity.is_active()
                     project_name = '%s, %s' % (project.name, activity.name)
 
         if alias_first:
@@ -182,7 +186,7 @@ class BaseUi(object):
         args.append(' (%s)' % project_name if project_name else '')
         text = "[%s] %s -> %s%s" % tuple(args)
 
-        if project and project.is_active():
+        if project and mapping_is_active:
             self.msg(text)
         else:
             self.msg(click.style(text, fg='red'))

--- a/taxi/ui/__init__.py
+++ b/taxi/ui/__init__.py
@@ -164,7 +164,7 @@ class BaseUi(object):
         if not project:
             project_name = ''
         else:
-            mapping_is_active = project.is_active()
+            mapping_is_active &= project.is_active()
             if mapping.mapping[1] is None:
                 project_name = project.name
                 mapping_name = mapping.mapping[0]
@@ -174,8 +174,7 @@ class BaseUi(object):
                 if activity is None:
                     project_name = '%s, ?' % (project.name)
                 else:
-                    if mapping_is_active:
-                        mapping_is_active = activity.is_active()
+                    mapping_is_active &= activity.is_active()
                     project_name = '%s, %s' % (project.name, activity.name)
 
         if alias_first:

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -135,7 +135,7 @@ def entries_file(tmpdir, config):
 
 @pytest.fixture
 def cli(config, data_dir):
-    def inner(cmd, args=None, input=None, return_stdout=True):
+    def inner(cmd, args=None, input=None, return_stdout=True, color=False):
         if not args:
             args = []
 
@@ -145,7 +145,7 @@ def cli(config, data_dir):
 
         runner = CliRunner()
         result = runner.invoke(
-            taxi_cli, args, input=input, standalone_mode=False, catch_exceptions=False
+            taxi_cli, args, input=input, standalone_mode=False, catch_exceptions=False, color=color
         )
 
         return result.output if return_stdout else result

--- a/tests/commands/test_alias.py
+++ b/tests/commands/test_alias.py
@@ -26,6 +26,12 @@ def projects_db(data_dir):
     project.activities.append(Activity(1, 'activity 1'))
     projects_list.append(project)
 
+    project = Project(45, '3rd active project with one inactive activity', Project.STATUS_ACTIVE)
+    project.backend = 'test'
+    project.activities.append(Activity(3, 'activity 3'))
+    project.activities.append(Activity(4, 'activity 4', False))
+    projects_list.append(project)
+
     projects_db.update(projects_list)
 
     return projects_db
@@ -36,7 +42,7 @@ def alias_config(config, projects_db):
     config.clear_section('test_aliases')
 
     aliases = [
-        ('inactive1', '42/1'), ('inactive2', '42/2'), ('active1', '43/1'), ('active2', '43/2'), ('p2_active', '44/1')
+        ('inactive1', '42/1'), ('inactive2', '42/2'), ('active1', '43/1'), ('active2', '43/2'), ('p2_active', '44/1'), ('p3_active_activity', '45/3'), ('p3_inactive_activity', '45/4')
     ]
 
     for alias, activity in aliases:
@@ -55,6 +61,8 @@ def test_alias_without_parameter_forwards_to_list(cli, alias_config):
         "[test] inactive1 -> 42/1 (not started project, activity 1)",
         "[test] inactive2 -> 42/2 (not started project, activity 2)",
         "[test] p2_active -> 44/1 (2nd active project, activity 1)",
+        "[test] p3_active_activity -> 45/3 (3rd active project with one inactive activity, activity 3)",
+        "[test] p3_inactive_activity -> 45/4 (3rd active project with one inactive activity, activity 4)",
     ]
 
 
@@ -71,6 +79,7 @@ def test_alias_search_mapping_partial(cli, alias_config):
         "[test] active1 -> 43/1 (active project, activity 1)",
         "[test] active2 -> 43/2 (active project, activity 2)",
         "[test] p2_active -> 44/1 (2nd active project, activity 1)",
+        "[test] p3_active_activity -> 45/3 (3rd active project with one inactive activity, activity 3)",
     ]
 
 

--- a/tests/commands/test_alias.py
+++ b/tests/commands/test_alias.py
@@ -1,4 +1,5 @@
 import pytest
+from click import style
 from freezegun import freeze_time
 
 from taxi.projects import Activity, Project, ProjectsDb
@@ -80,6 +81,17 @@ def test_alias_search_mapping_partial(cli, alias_config):
         "[test] active2 -> 43/2 (active project, activity 2)",
         "[test] p2_active -> 44/1 (2nd active project, activity 1)",
         "[test] p3_active_activity -> 45/3 (3rd active project with one inactive activity, activity 3)",
+    ]
+
+
+def test_alias_search_inactive_listed_in_red(cli, alias_config):
+    output = cli("alias", ["list", "inactive"], color=True)
+    lines = output.splitlines()
+
+    assert lines == [
+        style("[test] inactive1 -> 42/1 (not started project, activity 1)", fg="red"),
+        style("[test] inactive2 -> 42/2 (not started project, activity 2)", fg="red"),
+        style("[test] p3_inactive_activity -> 45/4 (3rd active project with one inactive activity, activity 4)", fg="red",),
     ]
 
 


### PR DESCRIPTION
Taxi handles inactive (or finished) projects, but some backends (namely Zebra) support having "inactive" activities (since 2013 apparently :-P ); this can easily be handled.