### PR TITLE
Update taxi zebra flake and add new python version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["38", "39", "310", "311"]
+        python-version: ["310", "311", "312", "313"]
 
     steps:
       - uses: actions/checkout@v3
@@ -31,8 +31,11 @@ jobs:
         if: "steps.nix-cache.outputs.cache-hit == 'true'"
         run: "nix-store --import < /tmp/nixcache"
 
-      - name: Run tests
-        run: nix build -L .#checks.x86_64-linux.taxiPython${{ matrix.python-version }}
+      - name: Run taxi tests
+        run: nix build -L .#checks.x86_64-linux.taxi-python${{ matrix.python-version }}
+
+      - name: Build taxi with all plugins
+        run: nix build -L .#taxi-with-all-plugins
 
       - name: "Export Nix store cache"
         if: "steps.nix-cache.outputs.cache-hit != 'true'"

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -143,9 +143,9 @@ python3: command not found
 Run the following command::
 
     $ python --version
-    Python 3.8.5
+    Python 3.13.4
 
-Check that the version is at least 3.7. If that’s the case, replace ``python3``
+Check that the version is at least 3.10. If that’s the case, replace ``python3``
 by ``python`` when running commands. If that’s not the case, install Python 3.
 
 First steps with Taxi

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -33,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701376520,
-        "narHash": "sha256-U3iGiOZqgu7wvVzgfoQzGGFMqNsDj/q/6zPIjCy7ajg=",
+        "lastModified": 1751876657,
+        "narHash": "sha256-L9vrktqkjlFNZEPHmgYgeGl46SxOY/jyyovgRfEWhhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c74cc3c3db2ed5e68895953d75c397797d499133",
+        "rev": "0826f5fcff02d8f29f3f2e6a8a71e881e92be976",
         "type": "github"
       },
       "original": {
@@ -51,6 +54,21 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -45,7 +45,7 @@ let
 
     nativeCheckInputs = [ python3.pkgs.pytestCheckHook python3.pkgs.freezegun ];
 
-    passthru = { inherit withPlugins; };
+    passthru = { inherit withPlugins availablePlugins; };
 
     meta = {
       homepage = "https://github.com/sephii/taxi";
@@ -56,16 +56,18 @@ let
 
   taxiZebra = python3.pkgs.buildPythonPackage rec {
     pname = "taxi_zebra";
-    version = "4.0.0";
+    version = "5.0.0";
 
     src = fetchFromGitHub {
       owner = "liip";
       repo = "taxi-zebra";
       rev = version;
-      sha256 = "sha256-syEGpv8CZOD+TLQskylTnwqCKJRPVVImRfyEwP+9Nuc=";
+      sha256 = "sha256-vwlCdeWvbmoKYdEwKVmBkQTokOY4MGaxnOU3t0CRDS4=";
     };
 
+    format = "pyproject";
     buildInputs = [ taxi ];
+    nativeBuildInputs = [ python3.pkgs.setuptools python3.pkgs.wheel ];
     propagatedBuildInputs = [ python3.pkgs.requests python3.pkgs.click ];
 
     meta = {
@@ -135,4 +137,4 @@ let
     clockify = taxiClockify;
   };
 in
-taxi
+  taxi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
     {name = "Sylvain Fankhauser", email = "sephi@fhtagn.top"},
 ]
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "click>=3.3",

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,12 @@
-{ callPackage, python3, ... }:
-(callPackage ./pkgs.nix { inherit python3; }).overrideAttrs (old: {
-  src = ./.;
-  propagatedBuildInputs = old.propagatedBuildInputs ++ [ python3.pkgs.pytest ];
-})
+{ pkgs ? import <nixpkgs> {} }:
+let
+  taxi = pkgs.callPackage ./pkgs.nix { inherit (pkgs) python3; };
+in
+pkgs.mkShell {
+  name = "taxi-dev-shell";
+
+  buildInputs = [
+    taxi
+    pkgs.python3.pkgs.pytest
+  ];
+}


### PR DESCRIPTION
- Update flake and cleanup structure
- Update taxi zebra to latest 5.0.0
- Remove Python < 3.10  (3.9 support ends in 3 months)
- Add Build with all plugins steps to make sure their flake definition is ok